### PR TITLE
update pool token mint description

### DIFF
--- a/programs/token-bonding-curve/src/instructions/initialize.rs
+++ b/programs/token-bonding-curve/src/instructions/initialize.rs
@@ -19,7 +19,7 @@ pub struct Initialize<'info> {
     pub token_a: AccountInfo<'info>,
     ///   3. `[]` token_b Account. Must be non zero, owned by swap authority.
     pub token_b: AccountInfo<'info>,
-    ///   4. `[writable]` Pool Token Mint. Must be empty, owned by swap authority.
+    ///   4. `[writable]` Pool Token Mint. Must be empty, owned by swap authority. Freeze authority must be null.
     #[account(mut)]
     pub pool: AccountInfo<'info>,
     ///   5. `[]` Pool Token Account to deposit trading and withdraw fees.


### PR DESCRIPTION
- added comment to initialize instruction that freeze authority must be null on the pool token mint
- the condition in the `processor.rs` can be found [here](https://github.com/rally-dfs/token-bonding-curve/blob/61c8102501736cfd2ba539f13f5ff725d6ac6bc6/programs/token-bonding-curve/src/processor.rs#L272) 